### PR TITLE
Prevented HSQL Exception from Being Thrown on Startup when Checking if the Server Is Already Running

### DIFF
--- a/src/main/java/com/broadleafcommerce/autoconfigure/HSQLDBServer.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/HSQLDBServer.java
@@ -69,7 +69,7 @@ public class HSQLDBServer implements SmartLifecycle {
     public boolean isRunning() {
         boolean isRunning = false;
         final int port = props.getIntegerProperty("server.port", 0);
-        final String url = "jdbc:hsqldb:hsql://localhost:" + port + "/"
+        final String url = "jdbc:hsqldb:hsql://127.0.0.1:" + port + "/"
                            + props.getProperty("server.dbname.0", "");
         final String username = "SA";
         final String password = "";

--- a/src/main/java/com/broadleafcommerce/autoconfigure/HSQLDatabaseAutoConfiguration.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/HSQLDatabaseAutoConfiguration.java
@@ -99,7 +99,7 @@ public class HSQLDatabaseAutoConfiguration {
                 .create()
                 .username("SA")
                 .password("")
-                .url("jdbc:hsqldb:hsql://localhost/" + props.getDbName())
+                .url("jdbc:hsqldb:hsql://127.0.0.1/" + props.getDbName())
                 .driverClassName("org.hsqldb.jdbcDriver")
                 .type(org.apache.tomcat.jdbc.pool.DataSource.class)
                 .build();


### PR DESCRIPTION
Original Slack conversation: https://blc.slack.com/archives/C3ZH6QRAQ/p1490987962636341

On startup and shutdown, the following exception is logged by HSQL:

```java
org.hsqldb.HsqlException: Network client is not a HSQLDB JDBC driver
    at org.hsqldb.error.Error.error(Unknown Source)
    at org.hsqldb.error.Error.error(Unknown Source)
    at org.hsqldb.server.ServerConnection.handshake(Unknown Source)
    at org.hsqldb.server.ServerConnection.init(Unknown Source)
    at org.hsqldb.server.ServerConnection.run(Unknown Source)
    at java.lang.Thread.run(Thread.java:745)
```

This is also logged when you startup the "other" app (i.e., if you startup admin first, then this error is logged when you start site, but it will appear it admin's logs not site's). It is caused by the way we were checking if the HSQL server was already running:

```java
try (Socket ignored = new Socket(InetAddress.getByName(null), props.getIntegerProperty("server.port", 0)))
```

This socket is, in fact, *not* an "HSQLDB JDBC driver". Therefore, to prevent this exception we should use a `java.sql.Connection` to test if the server is running instead. That way, the HSQL JDBC driver *will* be used when creating the connection. Also, we need to log an error if the connection is refused because the port we are trying to setup the HSQL server on is already in use.

I also added logging indicating whether the HSQL JDBC driver is missing and, if the server is already running, that we are not creating a duplicate server.

## Testing

1. Startup admin

Should not see the afore mentioned exception, instead you should see:

```java
2017-08-02 11:09:36.768  INFO 51223 --- [ost-startStop-1] c.b.autoconfigure.HSQLDBServer           : HSQL server is not running.
2017-08-02 11:09:36.769  INFO 51223 --- [ost-startStop-1] c.b.autoconfigure.HSQLDBServer           : Starting HSQL server...
2017-08-02 11:09:36.769  WARN 51223 --- [ost-startStop-1] c.b.autoconfigure.HSQLDBServer           : HSQL embedded database server is for demonstration purposes only and is not intended for production usage.
```

2. Start site:

```java
2017-08-02 11:12:05.689  INFO 51561 --- [ost-startStop-1] c.b.autoconfigure.HSQLDBServer           : HSQL server is already running. Will not start a new instance.
```

3. Shutdown site
    - Should see not exception