### PR TITLE
If the HSQLDB port is already tied up then don't attempt to start it

### DIFF
--- a/src/main/java/com/broadleafcommerce/autoconfigure/HSQLDBServer.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/HSQLDBServer.java
@@ -83,6 +83,7 @@ public class HSQLDBServer implements SmartLifecycle {
                           + "To find out the ID of the process using that port, open a terminal. Then, "
                           + "if on Mac OS or Linux, use `lsof -i :" + port + "`, "
                           + "or, if on Windows, use `netstat -ano | findstr " + port + "`.");
+                isRunning = true;
             } catch (Exception ignored) {
                 // otherwise, it's not in use, yet
                 LOG.info("HSQL server is not running.");


### PR DESCRIPTION
Previously, if there was something occupying port 9001 then HSQLDB would still attempt to start up. You would end up with this in your logs:

```console
2017-08-22 08:00:35.588 ERROR 92667 --- [ost-startStop-1] c.b.autoconfigure.HSQLDBServer           : Port,9001, is already in use but not by HSQL. To find out the ID of the process using that port, open a terminal. Then, if on Mac OS or Linux, use `lsof -i :9001`, or, if on Windows, use `netstat -ano | findstr 9001`.
2017-08-22 08:00:35.588  INFO 92667 --- [ost-startStop-1] c.b.autoconfigure.HSQLDBServer           : Starting HSQL server...
2017-08-22 08:00:35.588  WARN 92667 --- [ost-startStop-1] c.b.autoconfigure.HSQLDBServer           : HSQL embedded database server is for demonstration purposes only and is not intended for production usage.
[Server@6891c033]: Initiating startup sequence...
[Server@6891c033]: [Thread[HSQLDB Server @6891c033,5,main]]: run()/openServerSocket():
java.net.BindException: Address already in use
	at java.net.PlainSocketImpl.socketBind(PlainSocketImpl.java)
	at java.net.AbstractPlainSocketImpl.bind(AbstractPlainSocketImpl.java:387)
	at java.net.ServerSocket.bind(ServerSocket.java:375)
	at java.net.ServerSocket.<init>(ServerSocket.java:237)
	at java.net.ServerSocket.<init>(ServerSocket.java:128)
	at org.hsqldb.server.HsqlSocketFactory.createServerSocket(Unknown Source)
	at org.hsqldb.server.Server.openServerSocket(Unknown Source)
	at org.hsqldb.server.Server.run(Unknown Source)
	at org.hsqldb.server.Server.access$000(Unknown Source)
	at org.hsqldb.server.Server$ServerThread.run(Unknown Source)
[Server@6891c033]: Initiating shutdown sequence...
[Server@6891c033]: Shutdown sequence completed in 31 ms.
[Server@6891c033]: 2017-08-22 08:00:35.683 SHUTDOWN : System.exit() was not called
```

The fix is to return true for `isRunning()` so that Spring doesn't call `start()` within its lifecycle.