### PR TITLE
Support a hex to character conversion function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
             <version>${spring.boot.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.4</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/com/broadleafcommerce/autoconfigure/CustomFunctions.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/CustomFunctions.java
@@ -1,8 +1,30 @@
+/*-
+ * #%L
+ * BroadleafCommerce HSQLDB Database Starter
+ * %%
+ * Copyright (C) 2009 - 2019 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
 package com.broadleafcommerce.autoconfigure;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 
+/**
+ * Support a conversion from a hexidecimal value to a standard character string value
+ *
+ * @author Jeff Fischer
+ */
 public class CustomFunctions {
 
     public static String fromHex(String hex) {

--- a/src/main/java/com/broadleafcommerce/autoconfigure/CustomFunctions.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/CustomFunctions.java
@@ -1,0 +1,16 @@
+package com.broadleafcommerce.autoconfigure;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+
+public class CustomFunctions {
+
+    public static String fromHex(String hex) {
+        try {
+            return new String(Hex.decodeHex(hex.toCharArray()));
+        } catch (DecoderException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
In order to support dynamic sql cases, but avoid sql injection vulnerabilities, it is necessary to encode String params as hexidecimal. Then, before inserting or updating values, the database can execute a function to convert the hexidecimal to a String value. Sql injection is avoided, since the final String value is not part of the executed SQL query.

BroadleafCommerce/QA#3710